### PR TITLE
Fix checking for presence of bundler

### DIFF
--- a/testrails.rb
+++ b/testrails.rb
@@ -301,7 +301,7 @@ if File.exist? File.join(WORK, 'Gemfile')
   end
 
   install = <<-EOF
-    gem list bundler | grep -q #{bundler} && gem update bundler || gem #{install} bundler
+    gem list -i ^bundler$ | grep -q #{bundler} && gem update bundler || gem #{install} bundler
     (cd #{WORK}; rm -rf Gemfile.lock vendor; bundle install)
   EOF
 else


### PR DESCRIPTION
- Rubygems latest version does not return non-zero status when a gem is
  not present and we try to update it using `gem update bundler`.
- `gem list -i` gives proper status based on which we can double pipe
  next command to install bundler if it's not present.

      gem list -i bundler # bundler is not present
      $? => 1

      gem list -i bundler # bundler is present
      $? => 0