### PR TITLE
Fix editing test for creating line items

### DIFF
--- a/edition4/makedepot.rb
+++ b/edition4/makedepot.rb
@@ -1039,7 +1039,13 @@ section 9.4, 'Playtime' do
   desc 'Update parameters passed as well as expected target of redirect'
   edit 'test/*/line_items_controller_test.rb', 'create' do
     dcl 'should create', :mark => 'create' do
-      edit 'post :create', :highlight do
+      to_edit = if $rails_version =~ /^5/
+                  'post line_items_url'
+                else
+                  'post :create'
+                end
+
+      edit to_edit, :highlight do
         if self =~ /:line_item =>/
           msub /(:line_item =>.*)/, ':product_id => products(:ruby).id'
         else


### PR DESCRIPTION
- In Rails 5, controller tests inherit from Integration tests, so they
  specify direct URL in the test instead of action symbol.

  Before:
    post :create, params: {..}

  After
    post line_items_url, params: {..}