### PR TITLE
use var and not let

### DIFF
--- a/edition4/makedepot.rb
+++ b/edition4/makedepot.rb
@@ -1924,7 +1924,7 @@ section 11.2, 'Iteration F2: Creating an AJAX-Based Cart' do
     ext = ($rails_version =~ /^[45]/ ? 'coffee' : 'erb')
     edit "app/views/line_items/create.js.#{ext}" do |data|
       data.all =  <<-EOF.unindent(8)
-        #{ext == 'erb' ? 'let ' : ''}cart = document.getElementById("cart")
+        #{ext == 'erb' ? 'var ' : ''}cart = document.getElementById("cart")
         cart.innerHTML = "<%= j render(@cart) %>"
       EOF
     end
@@ -2079,7 +2079,7 @@ if notice
     edit "app/views/line_items/create.js.erb" do |data|
       data << %{
 // START_HIGHLIGHT
-let notice = document.getElementById("notice")
+var notice = document.getElementById("notice")
 if (notice) notice.style.display = "none"
 // END_HIGHLIGHT
 }


### PR DESCRIPTION
let seemed to create a weird problem when you executed the code more
than once - the browser thought the variable was being overridden and
the overall featue did not work.

Let me know if you agree or saw different behavior, but the section where we add to cart using AJAX did not work until I changed it to `var` (or removed the intermediate variable entirely)