### PR TITLE
fix: Update AWDwR book links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Introduction
 
 Agile Web Development with Rails (awdwr) is a test suite for the scenario
 found in the
-[book by the same name](https://pragprog.com/titles/rails4/agile-web-development-with-rails-4th-edition) published by Pragmatic Programmers.  It was originally developed out of self defence to keep up with the rapid pace of change in Rails itself, and has also proven valuable as a [system test](https://github.com/rails/rails/blob/master/RELEASING_RAILS.md#is-sam-ruby-happy--if-not-make-him-happy) for rails itself.
+[book by the same name](https://pragprog.com/titles/rails6) published by Pragmatic Programmers.  It was originally developed out of self defence to keep up with the rapid pace of change in Rails itself, and has also proven valuable as a [system test](https://github.com/rails/rails/blob/master/RELEASING_RAILS.md#is-sam-ruby-happy--if-not-make-him-happy) for rails itself.
 
 This code has been developed over a long period of time, and still has
 accommodations for things like:
@@ -20,7 +20,7 @@ either `rbenv` or `rvm`.  The dashboard can be run as CGI under Apache httpd,
 using Passenger on nginx, or simply with WebBrick.
 
 Instructions are provided separately for usage under [vagrant](vagrant#readme)
-and [cloud9](cloud9.md).  Or install 
+and [cloud9](cloud9.md).  Or install
 [Rails Dev Box](https://github.com/rails/rails-dev-box#readme), ssh into the vagrant machine and run the following command:
 
   eval "$(curl https://raw.githubusercontent.com/rubys/awdwr/master/rdb-setup)"
@@ -33,7 +33,7 @@ Installation
 
 Installation of all necessary dependencies from a fresh install of Ubuntu or
 Mac OS/X:
-  
+
     ruby setup.rb # see comments if dependencies aren't met
 
 Execution instructions:

--- a/edition4/data/README_FOR_APP
+++ b/edition4/data/README_FOR_APP
@@ -4,7 +4,7 @@ This application implements an online store, with a catalog, cart, and orders.
 
 It is divided into two main sections:
 
-* The buyer's side of the application manages the catalog, cart, 
+* The buyer's side of the application manages the catalog, cart,
   and checkout. It is implementation spans in four models and associated
   controllers and views: Cart, LineItem, Order, and Product.  Additionally,
   there is a StoreController for the store front itself, and a
@@ -16,7 +16,7 @@ It is divided into two main sections:
   method, and assisted by the Users and Carts resources.
 
 This code was produced as an example for the book {Agile Web Development with
-Rails}[http://www.pragprog.com/titles/rails4/agile-web-development-with-rails-4th-edition]. It should not be 
+Rails}[https://pragprog.com/titles/rails4]. It should not be 
 run as a real online store.
 
 === Authors
@@ -27,7 +27,7 @@ run as a real online store.
 
 === Warranty
 
-This code is provided for educational purposes only, and comes with 
+This code is provided for educational purposes only, and comes with
 absolutely no warranty. It should not be used in live applications.
 
 == Copyright


### PR DESCRIPTION
This PR Updates the book links as current links return 404.

@rubys repository description also have incorrect link.

Also, `edition4/data/README_FOR_APP` can be renamed to README.md. Thoughts?

Not a good place to ask (will move this to an issue) but if `edition5` and `edition6` are not going to be added, maybe `edition4` can be replaced with a different name or maybe this information can be added to `edition4/data/README_FOR_APP`.